### PR TITLE
Allow loading of external scripts

### DIFF
--- a/ajaxify-html5.js
+++ b/ajaxify-html5.js
@@ -158,7 +158,11 @@
 					// Add the scripts
 					$scripts.each(function(){
 						var $script = $(this), scriptText = $script.text(), scriptNode = document.createElement('script');
-						scriptNode.appendChild(document.createTextNode(scriptText));
+						if ( $script.attr('src') ) {
+							if ( !$script[0].async ) { scriptNode.async = false; }
+							scriptNode.src = $script.attr('src');
+						}
+    						scriptNode.appendChild(document.createTextNode(scriptText));
 						contentNode.appendChild(scriptNode);
 					});
 


### PR DESCRIPTION
External scripts weren't being loaded.  This patch respects the 'src' attribute on script elements within $dataContent, allowing external scripts to load.  This introduces a problem, however, since dynamically inserted external scripts load asynchronously. If scripts within $dataContent are order-dependent, this causes problems when the page is ajaxified, since there is no execution-order guarantee for these scripts. By setting 'scriptNode.async = false;' when this attribute isn't specified as true explicitly, dynamically inserted script nodes can be made to execute in-order (while still loading asynchronously). See http://wiki.whatwg.org/wiki/Dynamic_Script_Execution_Order.
