### PR TITLE
Trim the result of documentHtml() so jQuery 1.9.x can parse the string

### DIFF
--- a/ajaxify-html5.js
+++ b/ajaxify-html5.js
@@ -66,7 +66,7 @@
 			;
 			
 			// Return
-			return result;
+			return $.trim(result);
 		};
 		
 		// Ajaxify Helper


### PR DESCRIPTION
As of jQuery 1.9:

> HTML strings passed to jQuery() that start with something other than a less-than character will be interpreted as a selector. 

http://stage.jquery.com/upgrade-guide/1.9/#jquery-htmlstring-versus-jquery-selectorstring

The documentHTML() helper included in this doesn't trim the resulting string, so when it's passed to jQuery it includes white-space at the beginning of the string making jQuery **very** unhappy :).

I elected to use $.trim() rather than the native .trim() figuring better compatibility. I didn't benchmark to see the performance difference, however. That may be something to consider.

Note: This does not address the other 1.9.x issue that the ScrollTo plugin has. It is using $.msie which has been removed in 1.9.x as well. That still throws an error, but at least this fixes the actual jQuery 'ajaxification'. 
