### PR TITLE
Update links to ajaxify-html5.js and jquery-scrollto.js

### DIFF
--- a/ajaxify-bookmarklet-helper.js
+++ b/ajaxify-bookmarklet-helper.js
@@ -11,14 +11,14 @@
 
             // History.js & ScrollTo.js
             window.History || document.write('<script src="//browserstate.github.io/history.js/scripts/bundled/html4+html5/jquery.history.js"><\/script>');
-            jQuery.ScrollTo || document.write('<script src="//balupton.github.io/jquery-scrollto/scripts/jquery.scrollto.min.js"><\/script>');
+            jQuery.ScrollTo || document.write('<script src="//balupton.github.io/jquery-scrollto/lib/jquery-scrollto.js"><\/script>');
 
             interval = setInterval(function () {
                 if (window.History && window.History.initHtml4) {
                     clearInterval(interval);
 
                     // Ajaxify-html5.js
-                    document.write('<script src="//raw.github.com/browserstate/ajaxify/master/ajaxify-html5.js"><\/script>');
+                    document.write('<script src="//rawgithub.com/browserstate/ajaxify/master/ajaxify-html5.js"><\/script>');
 
                     interval = setInterval(function () {
                         if (jQuery.fn.ajaxify) {


### PR DESCRIPTION
`jquery-scrollto.js` had changed address

`ajaxify-html5.js` was served as `text/plain`. rawgithub.com fixes that
