### PR TITLE
Fix compatibility with latest scrollTo

### DIFF
--- a/ajaxify-html5.js
+++ b/ajaxify-html5.js
@@ -167,7 +167,7 @@
 					});
 
 					// Complete the change
-					if ( $body.ScrollTo||false ) { $body.ScrollTo(scrollOptions); } /* http://balupton.com/projects/jquery-scrollto */
+					if ( $body.scrollTo||false ) { $.scrollTo($body, settings.scrollOptions); } /* http://balupton.com/projects/jquery-scrollto */
 					$body.removeClass('loading');
 					$window.trigger(completedEventName);
 	


### PR DESCRIPTION
Ajaxify doesn't currently work with the latest version of scrollTo. The syntax seems to have changed slightly, and the plugin's name now begins with a lowercase "s" rather than a capital one.

The tweak in this pull request provides compatibility with the latest version of scrollTo. When scrollTo works properly, the page scrolls to the top after an AJAX load completes.
