### PR TITLE
Fixing issues for inline-javascript injection for IE

### DIFF
--- a/ajaxify-html5.js
+++ b/ajaxify-html5.js
@@ -162,7 +162,7 @@
 							if ( !$script[0].async ) { scriptNode.async = false; }
 							scriptNode.src = $script.attr('src');
 						}
-    						scriptNode.appendChild(document.createTextNode(scriptText));
+						scriptNode.text = scriptText;
 						contentNode.appendChild(scriptNode);
 					});
 


### PR DESCRIPTION
concerning this post on stackoverflow and my own experience it is more save to use "scriptNode.text" instead of "scriptNode.appendChild" when injecting inline javascript.

http://stackoverflow.com/questions/7090198/using-appendchild-with-ie-in-javascript
