### PR TITLE
Keep default behaviour (open in new tab) for ctrl+click

### DIFF
--- a/ajaxify-html5.js
+++ b/ajaxify-html5.js
@@ -83,7 +83,7 @@
 					title = $this.attr('title')||null;
 				
 				// Continue as normal for cmd clicks etc
-				if ( event.which == 2 || event.metaKey ) { return true; }
+				if ( event.which == 2 || event.metaKey || event.ctrlKey ) { return true; }
 				
 				// Ajaxify this link
 				History.pushState(null,title,url);


### PR DESCRIPTION
On Windows, `event.metaKey` is the Windows key so `ctrl+click` did not open a link in a new tab as expected.
