### PR TITLE
Do precise match on menu items if there is more than one matching menu item

### DIFF
--- a/ajaxify-html5.js
+++ b/ajaxify-html5.js
@@ -142,6 +142,9 @@
 					$menuChildren = $menu.find(menuChildrenSelector);
 					$menuChildren.filter(activeSelector).removeClass(activeClass);
 					$menuChildren = $menuChildren.has('a[href^="'+relativeUrl+'"],a[href^="/'+relativeUrl+'"],a[href^="'+url+'"]');
+					if ( $menuChildren.length > 1 ) {
+						$menuChildren = $menuChildren.has('a[href="'+relativeUrl+'"],a[href="/'+relativeUrl+'"],a[href="'+url+'"]');
+					}
 					if ( $menuChildren.length === 1 ) { $menuChildren.addClass(activeClass); }
 
 					// Update the content


### PR DESCRIPTION
I had a problem, where ajaxify would not make my "Homepage" menu item the active menu item.

Take this sample code:

``` html
<ul id="menu" role="navigation">
        <li class="active"><a href="/">Home</a></li>
        <li><a href="/page1/">Page 1</a></li>
        <li><a href="/page2/">Page 2</a></li>
        <li><a href="/page3/">Page 3</a></li>
        <li><a href="/page4/">Page 4</a></li>
</ul>
```

If you had that on an ajaxified page, and clicked on Page 1, the second li would be .active as expected. If you then click on Home, you would get this result:

``` html
<ul id="menu" role="navigation">
        <li class=""><a href="/">Home</a></li>
        <li class=""><a href="/page1/">Page 1</a></li>
        <li><a href="/page2/">Page 2</a></li>
        <li><a href="/page3/">Page 3</a></li>
        <li><a href="/page4/">Page 4</a></li>
</ul>
```

The reason being, that all the li's is matching the following selector, as they all start with a slash and that relativeUrl is an empty string:

``` js
...has('a[href^="'+relativeUrl+'"],a[href^="/'+relativeUrl+'"],a[href^="'+url+'"]')
```

Thus, to address this issue, I do a precise match (href= (href equals) instead of href^= (href starts with)) if more than one match is found.

I am not aware of any cases where this change would be a problem. I apologize in advance, should I be mistaken.
