### PR TITLE
Updated google analytics tracking to universal analytics

### DIFF
--- a/ajaxify-html5.js
+++ b/ajaxify-html5.js
@@ -172,8 +172,8 @@
 					$window.trigger(completedEventName);
 	
 					// Inform Google Analytics of the change
-					if ( typeof window._gaq !== 'undefined' ) {
-						window._gaq.push(['_trackPageview', relativeUrl]);
+					if ( typeof window.ga !== 'undefined' ) {
+						window.ga('send', 'pageview', relativeUrl);
 					}
 
 					// Inform ReInvigorate of a state change

--- a/ajaxify-html5.js
+++ b/ajaxify-html5.js
@@ -173,7 +173,11 @@
 	
 					// Inform Google Analytics of the change
 					if ( typeof window.ga !== 'undefined' ) {
+						// Universal Analytics
 						window.ga('send', 'pageview', relativeUrl);
+					} else if ( typeof window._gaq !== 'undefined' ) {
+						// Legacy analytics
+						window._gaq.push(['_trackPageview', relativeUrl]);
 					}
 
 					// Inform ReInvigorate of a state change


### PR DESCRIPTION
[Universal Analytics](https://developers.google.com/analytics/devguides/collection/upgrade/?hl=en_US) has been released for quite some time now so I figured it would be a good thing to update the AJAX success callback with the new pageview call.
