### PR TITLE
FIX for detect relative protocol external links

### DIFF
--- a/ajaxify-html5.js
+++ b/ajaxify-html5.js
@@ -49,11 +49,10 @@
 				url = $this.attr('href')||'',
 				isInternalLink;
 			
-			// Check link
-			isInternalLink = url.substring(0,rootUrl.length) === rootUrl || url.indexOf(':') === -1;
-			
-			// Ignore or Keep
-			return isInternalLink;
+			var match = url.match(/^([^:\/?#]+:)?(?:\/\/([^\/?#]*))?([^?#]+)?(\?[^#]*)?(#.*)?/);
+			if (typeof match[1] === "string" && match[1].length > 0 && match[1].toLowerCase() !== location.protocol) return false;
+			if (typeof match[2] === "string" && match[2].length > 0 && match[2].replace(new RegExp(":("+{"http:":80,"https:":443}[location.protocol]+")?$"), "") !== location.host) return false;
+			return true;
 		};
 		
 		// HTML Helper


### PR DESCRIPTION
Some URL's with relative protocol, such as, `//example.com/whatever/` is not detects as external and
ajaxify try to load `http://inteernal.site/example.com/whatever`, which is incorrect.
These regulars expressions fix that and external links detect properly.

Detect code get from http://stackoverflow.com/questions/6238351/fastest-way-to-detect-external-urls and adaptive to ajaxify.

Worked well!
